### PR TITLE
[move] : 라우트 그룹을 위한 페이지 컴포넌트 경로 이동

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>로그인 페이지입니다.</div>;
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,3 @@
+export default function Register() {
+  return <div>회원가입 페이지입니다.</div>;
+}

--- a/src/app/(main)/community/[type]/[id]/page.tsx
+++ b/src/app/(main)/community/[type]/[id]/page.tsx
@@ -8,7 +8,7 @@ export default function PostView() {
     <>
       <Header
         left={{
-          href: '..',
+          href: '/',
           src: '/assets/icons/arrow_left.svg',
           alt: '뒤로가기',
         }}

--- a/src/app/(main)/community/[type]/new/page.tsx
+++ b/src/app/(main)/community/[type]/new/page.tsx
@@ -6,7 +6,7 @@ export default function NewPost() {
     <>
       <Header
         left={{
-          href: '../',
+          href: '/',
           src: '/assets/icons/arrow_left.svg',
           alt: '뒤로가기',
         }}

--- a/src/app/(main)/community/[type]/page.tsx
+++ b/src/app/(main)/community/[type]/page.tsx
@@ -1,0 +1,19 @@
+import { BoardPage } from '@/components/pages';
+import { notFound } from 'next/navigation';
+
+const allowedTypeList = ['freeboard', 'recipe', 'discussion'];
+
+export default async function Board({
+  params,
+}: {
+  params: Promise<{ type: string }>;
+}) {
+  const { type } = await params;
+  if (!allowedTypeList.includes(type)) notFound();
+
+  return (
+    <>
+      <BoardPage />
+    </>
+  );
+}

--- a/src/app/(main)/community/[type]/page.tsx
+++ b/src/app/(main)/community/[type]/page.tsx
@@ -1,7 +1,7 @@
 import { BoardPage } from '@/components/pages';
 import { notFound } from 'next/navigation';
 
-const allowedTypeList = ['freeboard', 'recipe', 'discussion'];
+const allowedTypeList = ['freeboard', 'myrecipe', 'discussion'];
 
 export default async function Board({
   params,

--- a/src/app/(main)/feeds/page.tsx
+++ b/src/app/(main)/feeds/page.tsx
@@ -1,0 +1,26 @@
+import { FeedList } from '@/components/feeds';
+import { Content, Header } from '@/components/layout';
+
+export default function Feeds() {
+  return (
+    <>
+      <Header
+        left={{
+          href: '/',
+          src: '/assets/icons/arrow_left.svg',
+          alt: '뒤로가기',
+        }}
+        right={{
+          href: '..',
+          src: '/assets/icons/grid_2x2.svg',
+          alt: '그리드 형식으로 보기',
+        }}
+      >
+        <h1 className="text-heading-xl">피드</h1>
+      </Header>
+      <Content>
+        <FeedList />
+      </Content>
+    </>
+  );
+}

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,0 +1,59 @@
+import { Button, NavLink, TextInput } from '@/components/common';
+import {
+  MainBannerCarousel,
+  MainSection,
+  NoticeBar,
+  QuickLink,
+} from '@/components/home';
+import { Content, Header } from '@/components/layout';
+
+export default async function Home() {
+  return (
+    <>
+      <Header>
+        <NavLink href="/">
+          <h1 className="text-heading-2xl">놀잇터</h1>
+        </NavLink>
+      </Header>
+      <Content>
+        <form className="flex gap-2">
+          <TextInput
+            id="search"
+            name="search"
+            placeholder="검색어를 입력해주세요."
+            className="rounded-full"
+          />
+          <Button type="submit">🔍</Button>
+        </form>
+
+        <MainBannerCarousel />
+
+        <MainSection title="바로가기">
+          <div className="flex h-16 items-center gap-2">
+            <QuickLink
+              className="w-full"
+              to="/community/myrecipe"
+              image={{
+                src: '/assets/images/recipe_book.png',
+                alt: '나만의 레시피',
+              }}
+            >
+              나만의 레시피
+            </QuickLink>
+            <QuickLink
+              className="w-full"
+              to="/community/freeboard"
+              image={{ src: '/assets/images/freeboard.png', alt: '자유게시판' }}
+            >
+              자유게시판
+            </QuickLink>
+          </div>
+        </MainSection>
+
+        <MainSection title="공지사항">
+          <NoticeBar />
+        </MainSection>
+      </Content>
+    </>
+  );
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,14 @@
+import { Footer } from '@/components/layout';
+
+export default function MainLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { Noto_Sans_KR } from 'next/font/google';
-import { Footer } from '@/components/layout';
 import { ModalContextProvider } from '@/contexts/ModalContext';
 import './globals.css';
 
@@ -25,7 +24,6 @@ export default function RootLayout({
       >
         <div className="relative mx-auto min-h-dvh w-full max-w-md min-w-xs bg-white">
           <ModalContextProvider>{children}</ModalContextProvider>
-          <Footer />
         </div>
         <div id="modal"></div>
       </body>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-10">
+      <h1>404 페이지를 찾을 수 없습니다!</h1>
+      <Link href="/home">홈으로 가기</Link>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,60 +1,7 @@
-import { Button, NavLink, TextInput } from '@/components/common';
-import { Carousel, MainSection, NoticeBar, QuickLink } from '@/components/home';
-import { Content, Header } from '@/components/layout';
-
-import mockData from '@/data/home/banners.json';
-
 export default async function Home() {
   return (
     <>
-      <Header>
-        <NavLink href="/" refresh>
-          <h1 className="text-heading-2xl">놀잇터</h1>
-        </NavLink>
-      </Header>
-      <Content>
-        <form className="flex gap-2">
-          <TextInput
-            id="search"
-            name="search"
-            placeholder="검색어를 입력해주세요."
-            className="rounded-full"
-          />
-          <Button type="submit">🔍</Button>
-        </form>
-
-        <Carousel
-          data={mockData}
-          autoplay={{ delay: 3000, stopOnInteraction: false }}
-          options={{ loop: true }}
-        />
-
-        <MainSection title="바로가기">
-          <div className="flex h-16 items-center gap-2">
-            <QuickLink
-              className="w-full"
-              to="/"
-              image={{
-                src: '/assets/images/recipe_book.png',
-                alt: '나만의 레시피',
-              }}
-            >
-              나만의 레시피
-            </QuickLink>
-            <QuickLink
-              className="w-full"
-              to="/posts"
-              image={{ src: '/assets/images/freeboard.png', alt: '자유게시판' }}
-            >
-              자유게시판
-            </QuickLink>
-          </div>
-        </MainSection>
-
-        <MainSection title="공지사항">
-          <NoticeBar />
-        </MainSection>
-      </Content>
+      <h1>Hello world!</h1>
     </>
   );
 }

--- a/src/components/pages/BoardPage.tsx
+++ b/src/components/pages/BoardPage.tsx
@@ -5,12 +5,12 @@ import { Content, Header } from '@/components/layout';
 import mockCategoryData from '@/data/board/category.json';
 import mockPostsData from '@/data/board/posts.json';
 
-export default function Board() {
+export default function BoardPage() {
   return (
     <>
       <Header
         left={{
-          href: '../',
+          href: '/',
           src: '/assets/icons/arrow_left.svg',
           alt: '뒤로가기',
         }}
@@ -18,7 +18,6 @@ export default function Board() {
         <h1 className="text-heading-xl">자유 게시판</h1>
       </Header>
       <Content>
-        {/* Sort Tab UI */}
         <div className="flex items-center gap-3">
           <Button className="border-none bg-none p-0 text-black" type="button">
             <span className="text-heading-xl">전체</span>
@@ -28,7 +27,6 @@ export default function Board() {
           </Button>
         </div>
 
-        {/* Category Filter Tab UI */}
         <div className="no-scrollbar overflow-x-scroll">
           <PostCategoryTab tabData={mockCategoryData.data} />
         </div>

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -1,0 +1,1 @@
+export { default as BoardPage } from './BoardPage';


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] config 파일 변경
      <br />

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

<br />

### PR 내용 요약
- 라우트 그룹을 위한 페이지 컴포넌트 경로 변경
<br />

### PR 상세
- 라우트 그룹을 사용하여 비인증상태 페이지 auth와 인증상태 페이지 main으로 그룹화
- 그룹에 따른 레이아웃 분기
- 게시판쪽 동적 라우트 적용 및 게시판 페이지 컴포넌트로 분리
- 루트경로 not-found 페이지 추가
<br />

### 스크린샷
<img width="199" height="359" alt="image" src="https://github.com/user-attachments/assets/25dd12db-28a4-46f8-a7dc-41c90e59de35" />

<br />

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 로그인 및 회원가입 페이지 추가
  * 커뮤니티 타입별 목록 페이지 추가(허용되지 않은 타입은 404 처리)
  * 피드 페이지 추가
  * 메인 홈 페이지 신규 구성(검색, 배너, 바로가기, 공지)
  * 전역 404 페이지 추가(홈으로 이동 링크 제공)
* Refactor
  * 푸터 렌더링 위치를 메인 레이아웃으로 이동
  * 커뮤니티 게시글 보기/작성 화면의 뒤로가기 경로를 루트로 통일
  * 루트 페이지 화면을 임시로 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->